### PR TITLE
Parallel: allow radar precipitation source

### DIFF
--- a/DHSVM/sourcecode/InitMetSources.c
+++ b/DHSVM/sourcecode/InitMetSources.c
@@ -661,6 +661,7 @@ void InitRadar(LISTPTR Input, MAPSIZE * Map, TIMESTRUCT * Time,
 
   if (!CopyFloat(&(Radar->DY), StrEnv[radar_grid].VarStr, 1))
     ReportError(StrEnv[radar_grid].KeyName, 51);
+  Radar->DX = Radar->DY;
 
   Radar->DXY = sqrt(Radar->DX * Radar->DX + Radar->DY * Radar->DY);
   Radar->X = 0;

--- a/DHSVM/sourcecode/InitMetSources.c
+++ b/DHSVM/sourcecode/InitMetSources.c
@@ -713,10 +713,19 @@ void InitRadar(LISTPTR Input, MAPSIZE * Map, TIMESTRUCT * Time,
      Radar->X = 0;
      Radar->Y = 0;
   */
+
+  /* the same map will be used for all processes */
+  Radar->gNX = Radar->NX;
+  Radar->gNY = Radar->NY;
+  Radar->NumCells = Radar->NX*Radar->NY;
+  Radar->AllCells = Radar->NumCells;
+
   Radar->OffsetX = Round(((float)(Radar->Xorig - Map->Xorig)) /
                          ((float)Map->DX));
   Radar->OffsetY = Round(((float)(Radar->Yorig - Map->Yorig)) /
                          ((float)Map->DY));
+
+  Radar->dist = GA4Map(Radar, "Radar");
 
   if (Radar->OffsetX > 0 || Radar->OffsetY < 0)
     ReportError("Input Options File", 31);

--- a/DHSVM/sourcecode/ReadRadarMap.c
+++ b/DHSVM/sourcecode/ReadRadarMap.c
@@ -49,7 +49,7 @@ void ReadRadarMap(DATE * Current, DATE * StartRadar, int Dt, MAPSIZE * Radar,
   RadarStep = NumberOfSteps(StartRadar, Current, Dt);
 
   /* Read the precipitation */
-  Read2DMatrix(FileName, Array, NumberType, Radar, RadarStep, "", 0);
+  Read2DMatrixAll(FileName, Array, NumberType, Radar, RadarStep, "", 0);
 
   for (y = 0, i = 0; y < Radar->NY; y++)
     for (x = 0; x < Radar->NX; x++, i++)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ This branch of DHSVM has been modified to run in parallel using
 ## Hydrologic Processes / Options not Implemented in Parallel 
 
 * `Flow Routing` = `UNIT_HYDROGRAPH`
-* `Precipitation Source` = `RADAR`
+
+There may be other options that don't work. These are what's known.
 
 ## Requirements
 


### PR DESCRIPTION
Fixes pnnl/DHSVM-PNNL#13. 
Precipitation Source = RADAR is now works in parallel. This is handled like MM5 input, i.e. the entire precip map is distributed to all processes.  This is OK when the radar resolution is low.  This may need to be rethought if radar resolution is close to the DEM.  