### PR TITLE
RootBrent: just issue a warning

### DIFF
--- a/DHSVM/sourcecode/RootBrent.c
+++ b/DHSVM/sourcecode/RootBrent.c
@@ -134,8 +134,8 @@ float RootBrent(int y, int x, float LowerBound, float UpperBound,
     j++;
   }
   if ((fa * fb) >= 0) {
-    return current;
     ReportWarning(ErrorString, 34);
+    return current;
   }
   fc = fb;
 

--- a/DHSVM/sourcecode/RootBrent.c
+++ b/DHSVM/sourcecode/RootBrent.c
@@ -82,7 +82,7 @@
   Comments     :
 *****************************************************************************/
 float RootBrent(int y, int x, float LowerBound, float UpperBound,
-		float (*Function) (float Estimate, va_list ap), ...)
+		float current, float (*Function) (float Estimate, va_list ap), ...)
 {
   const char *Routine = "RootBrent";
   char ErrorString[MAXSTRING + 1];
@@ -134,7 +134,8 @@ float RootBrent(int y, int x, float LowerBound, float UpperBound,
     j++;
   }
   if ((fa * fb) >= 0) {
-    ReportError(ErrorString, 34);
+    return current;
+    ReportWarning(ErrorString, 34);
   }
   fc = fb;
 
@@ -211,5 +212,6 @@ float RootBrent(int y, int x, float LowerBound, float UpperBound,
       eval++;
     }
   }
-  ReportError(ErrorString, 33);
+  ReportWarning(ErrorString, 33);
+  return current;
 }

--- a/DHSVM/sourcecode/SensibleHeatFlux.c
+++ b/DHSVM/sourcecode/SensibleHeatFlux.c
@@ -71,7 +71,8 @@ void SensibleHeatFlux(int y, int x, int Dt, float Ra, float ZRef,
      sum of the terms of the energy balance equals 0 */
 
   LocalSoil->TSurf =
-    RootBrent(y, x, MinTSurf, MaxTSurf, SurfaceEnergyBalance, Dt, Ra, ZRef,
+    RootBrent(y, x, MinTSurf, MaxTSurf, LocalSoil->TSurf,
+              SurfaceEnergyBalance, Dt, Ra, ZRef,
 	      Displacement, Z0, LocalMet->Wind, NetShort, LongIn,
 	      LocalMet->AirDens, LocalMet->Lv, ETot, KhEff,
 	      SoilType->Ch[0], SoilType->Porosity[0], LocalSoil->Moist[0],

--- a/DHSVM/sourcecode/SnowMelt.c
+++ b/DHSVM/sourcecode/SnowMelt.c
@@ -230,7 +230,7 @@ float SnowMelt(int y, int x, int Dt, float Z, float Displacement, float Z0,
     /* Calculate surface layer temperature using "Brent method" */
 
     *TSurf = RootBrent(y, x, (float)(*TSurf - DELTAT), (float) 0.0,
-      SnowPackEnergyBalance, Dt, BaseRa, Z, Displacement,
+      *TSurf, SnowPackEnergyBalance, Dt, BaseRa, Z, Displacement,
       Z0, Wind, ShortRad, LongRadIn, AirDens, Lv, Tair,
       Press, Vpd, EactAir, RainFall, SurfaceSwq, *SurfWater,
       OldTSurf, &RefreezeEnergy, VaporMassFlux);

--- a/DHSVM/sourcecode/brent.h
+++ b/DHSVM/sourcecode/brent.h
@@ -17,7 +17,7 @@
 #define BRENT_H
 
 float RootBrent(int y, int x, float LowerBound, float UpperBound,
-		float (*Function) (float Estimate, va_list ap), ...);
+		float current, float (*Function) (float Estimate, va_list ap), ...);
 
 #define MACHEPS      3e-8	/* machine floating point precision (float) */
 #define T            1e-5	/* tolerance */


### PR DESCRIPTION
I have modified the `RootBrent()` routine to just issue a warning if it has trouble, rather than a fatal error.  If an error occurs, either solution not bracketed or too many iterations, the same message is produced, and the "current" value is returned.  

I've used this in the parallel branch to get past the `RootBrent` problem. There is typically a flurry of warning messages from `RootBrent()`, but my simulations, at least, continue an produce reasonable results. 