### PR TITLE
Adding option for calculating wy annual peak swe, peak swe date, snow…

### DIFF
--- a/DHSVM/config/Input.Lawler.Gap
+++ b/DHSVM/config/Input.Lawler.Gap
@@ -60,7 +60,8 @@ Variable Light Transmittance = TRUE       # TRUE if light transmittance changes 
 Canopy Gapping = TRUE
 Snow Sliding = FALSE                      # this function is not available - needs more tests
 Precipitation Separation = FALSE          # TRUE if snow and rain are separately provided in meterological input data (e.g. WRF)
-
+Snow Statistics = FALSE                   # TRUE if snow statistics for each water year calculated, needs to specify variable and date in map section
+ 
 ##########################################################################################################
 # MODEL AREA SECTION
 ##########################################################################################################
@@ -339,11 +340,26 @@ Number of Model States     =  0           # Number of model states to dump
 
 State Date               1 = 1/1/1970-00
 
-
 ################ MODEL MAPS ####################################################
 
 Number of Map Variables    = 0            # Number of different variables for
                                           # which you want to output maps
+										  
+Map Variable             1 = 412       #  Peak SWE
+Map Layer                1 = 1            
+Number of Maps           1 = 4          
+Map Date 1               1 = 09/30/2008-00   
+
+Map Variable             2 = 414       # Melt Out Date
+Map Layer                2 = 1            
+Number of Maps           2 = 4          
+Map Date 1               2 = 09/30/2008-00  
+  
+
+Map Variable             3 = 413        # Peak SWE Date
+Map Layer                3 = 1            
+Number of Maps           3 = 4          
+Map Date 1               3 = 09/30/2008-00  
 
 ######################################### MODEL IMAGES #################################################################
 

--- a/DHSVM/sourcecode/Calendar.c
+++ b/DHSVM/sourcecode/Calendar.c
@@ -273,6 +273,27 @@ uchar IsNewMonth(DATE *Now, int Interval)
 }
 
 /*****************************************************************************
+  IsNewWaterYear()
+*****************************************************************************/
+uchar IsNewWaterYear(DATE *Now)
+{
+  int Year;
+  int Month;
+  int Day;
+  int Hour;
+  int Min;
+  double Sec;
+  double Julian;
+
+  Julian = Now->Julian;
+  JulianDayToGregorian(Julian, &Year, &Month, &Day, &Hour, &Min, &Sec);
+  if (Month == 10 && Day == 1 && Hour == 0)
+    return TRUE;
+  else
+    return FALSE;
+}
+
+/*****************************************************************************
   IsNewDay()
 *****************************************************************************/
 uchar IsNewDay(int DayStep)

--- a/DHSVM/sourcecode/Calendar.h
+++ b/DHSVM/sourcecode/Calendar.h
@@ -67,6 +67,7 @@ uchar IsEqualTime(DATE *Day1, DATE *Day2);
 uchar IsLeapYear(int Year);
 uchar IsNewDay(int DayStep);
 uchar IsNewMonth(DATE *Now, int Interval);
+uchar IsNewWaterYear(DATE *Now);
 DATE NextDate(DATE *Current, int Interval);
 int NumberOfSteps(DATE *Start, DATE *End, int Interval);
 void PrintDate(DATE *Day, FILE *OutFile);

--- a/DHSVM/sourcecode/ExecDump.c
+++ b/DHSVM/sourcecode/ExecDump.c
@@ -810,6 +810,69 @@ void DumpMap(MAPSIZE *Map, DATE *Current, MAPDUMP *DMap, TOPOPIX **TopoMap,
       ReportError(VarIDStr, 66);
     break;
 
+    case 412:
+    if (DMap->Resolution == MAP_OUTPUT) {
+      for (y = 0; y < Map->NY; y++)
+        for (x = 0; x < Map->NX; x++)
+          ((float *)Array)[y * Map->NX + x] = SnowMap[y][x].MaxSwe;
+      Write2DMatrix(DMap->FileName, Array, DMap->NumberType, Map,
+        DMap, Index);
+    }
+    else if (DMap->Resolution == IMAGE_OUTPUT) {
+      for (y = 0; y < Map->NY; y++)
+        for (x = 0; x < Map->NX; x++)
+          ((unsigned char *)Array)[y * Map->NX + x] =
+          (unsigned char)((SnowMap[y][x].MaxSwe - Offset) /
+            Range * MAXUCHAR);
+      Write2DMatrix(DMap->FileName, Array, NC_BYTE, Map, DMap, Index);
+
+    }
+    else
+      ReportError(VarIDStr, 66);
+    break;
+  
+  case 413:
+    if (DMap->Resolution == MAP_OUTPUT) {
+      for (y = 0; y < Map->NY; y++)
+        for (x = 0; x < Map->NX; x++)
+          ((unsigned int *)Array)[y * Map->NX + x] = SnowMap[y][x].MaxSweDate;
+      Write2DMatrix(DMap->FileName, Array, DMap->NumberType, Map,
+        DMap, Index);
+    }
+    else if (DMap->Resolution == IMAGE_OUTPUT) {
+      for (y = 0; y < Map->NY; y++)
+        for (x = 0; x < Map->NX; x++)
+          ((unsigned char *)Array)[y * Map->NX + x] =
+          (unsigned char)((SnowMap[y][x].MaxSweDate - Offset) /
+            Range * MAXUCHAR);
+      Write2DMatrix(DMap->FileName, Array, NC_BYTE, Map, DMap, Index);
+
+    }
+    else
+      ReportError(VarIDStr, 66);
+    break;
+
+  case 414:
+    if (DMap->Resolution == MAP_OUTPUT) {
+      for (y = 0; y < Map->NY; y++)
+        for (x = 0; x < Map->NX; x++)
+          ((unsigned int *)Array)[y * Map->NX + x] = SnowMap[y][x].MeltOutDate;
+      Write2DMatrix(DMap->FileName, Array, DMap->NumberType, Map,
+        DMap, Index);
+    }
+    else if (DMap->Resolution == IMAGE_OUTPUT) {
+      for (y = 0; y < Map->NY; y++)
+        for (x = 0; x < Map->NX; x++)
+          ((unsigned char *)Array)[y * Map->NX + x] =
+          (unsigned char)((SnowMap[y][x].MeltOutDate - Offset) /
+            Range * MAXUCHAR);
+      Write2DMatrix(DMap->FileName, Array, NC_BYTE, Map, DMap, Index);
+
+    }
+    else
+      ReportError(VarIDStr, 66);
+    break;
+
   case 501:
     if (DMap->Resolution == MAP_OUTPUT) {
       for (y = 0; y < Map->NY; y++) {

--- a/DHSVM/sourcecode/InitConstants.c
+++ b/DHSVM/sourcecode/InitConstants.c
@@ -98,6 +98,7 @@ void InitConstants(LISTPTR Input, OPTIONSTRUCT *Options, MAPSIZE *Map,
     {"OPTIONS", "CANOPY GAPPING", "", "" },
     {"OPTIONS", "SNOW SLIDING", "", "" },
     {"OPTIONS", "PRECIPITATION SEPARATION", "", "FALSE" },
+    {"OPTIONS", "SNOW STATISTICS", "", "FALSE" },
     {"AREA", "COORDINATE SYSTEM", "", ""},
     {"AREA", "EXTREME NORTH", "", ""},
     {"AREA", "EXTREME WEST", "", ""},
@@ -325,6 +326,14 @@ void InitConstants(LISTPTR Input, OPTIONSTRUCT *Options, MAPSIZE *Map,
     Options->SnowSlide = FALSE;
   else
     ReportError(StrEnv[snowslide].KeyName, 51);
+  
+  /* Determine if dumps snow stats */
+  if (strncmp(StrEnv[snowstats].VarStr, "TRUE", 4) == 0)
+    Options->SnowStats = TRUE;
+  else if (strncmp(StrEnv[snowstats].VarStr, "FALSE", 5) == 0)
+    Options->SnowStats = FALSE;
+  else
+    ReportError(StrEnv[snowstats].KeyName, 51);
   
   /* Determine if use separate input of rain and snow */
   if (strncmp(StrEnv[sepr].VarStr, "TRUE", 4) == 0)

--- a/DHSVM/sourcecode/InitNewMonth.c
+++ b/DHSVM/sourcecode/InitNewMonth.c
@@ -12,6 +12,7 @@
  * FUNCTIONS:    InitNewMonth()
  *               InitNewDay()
  *               InitNewStep()
+ *               InitNewWaterYear()
  * COMMENTS:
  * $Id: InitNewMonth.c,v 3.1 2013/02/06 ning Exp $
  */
@@ -365,4 +366,33 @@ void InitNewStep(INPUTFILES *InFiles, MAPSIZE *Map, TIMESTRUCT *Time,
   if ((Options->MM5 == TRUE && Options->QPF == TRUE) || Options->MM5 == FALSE)
     GetMetData(Options, Time, NSoilLayers, NStats, SolarGeo->SunMax, Stat,
       Radar, RadarMap, RadarFileName);
+}
+
+/*****************************************************************************
+   InitNewWaterYear()
+   At the start of a new water year, re-initiate the SWE stats maps 
+ *****************************************************************************/
+void InitNewWaterYear(TIMESTRUCT *Time, OPTIONSTRUCT *Options, MAPSIZE *Map,
+                TOPOPIX **TopoMap, SNOWPIX **SnowMap)
+{
+  const char *Routine = "InitNewYear";
+  int y, x;
+  if (DEBUG)
+    printf("Initializing new water year \n");
+
+  /* If PRISM precipitation fields are being used to interpolate the
+     observed precipitation fields, then read in the new months field */
+
+  if (Options->SnowStats == TRUE) {
+    printf("resetting SWE stats map %d \n", Time->Current.Year);
+    for (y = 0; y < Map->NY; y++) {
+      for (x = 0; x < Map->NX; x++) {
+        if (INBASIN(TopoMap[y][x].Mask)) {
+          SnowMap[y][x].MaxSwe = 0.0;
+          SnowMap[y][x].MaxSweDate = 0;
+          SnowMap[y][x].MeltOutDate = 0;
+        }
+      }
+    }
+  }
 }

--- a/DHSVM/sourcecode/MainDHSVM.c
+++ b/DHSVM/sourcecode/MainDHSVM.c
@@ -272,6 +272,9 @@ int main(int argc, char **argv)
     /* redistribute snow based on snow surface slope etc */
     if (Options.SnowSlide)
 	    Avalanche(&Map, TopoMap, &Time, &Options, SnowMap);
+    
+    if (IsNewWaterYear(&(Time.Current)))
+      InitNewWaterYear(&Time, &Options, &Map, TopoMap, SnowMap);
 
     if (IsNewMonth(&(Time.Current), Time.Dt))
       InitNewMonth(&Time, &Options, &Map, TopoMap, PrismMap, ShadowMap,
@@ -383,6 +386,9 @@ int main(int argc, char **argv)
     
     Aggregate(&Map, &Options, TopoMap, &Soil, &Veg, VegMap, EvapMap, PrecipMap,
 	      RadiationMap, SnowMap, SoilMap, &Total, VType, Network, &ChannelData, &roadarea, Time.Dt);
+    
+    if (Options.SnowStats)
+      SnowStats(&(Time.Current), &Map, &Options, TopoMap, SnowMap, Time.Dt);
     
     MassBalance(&(Time.Current), &(Time.Start), &(Dump.Balance), &Total, &Mass);
 

--- a/DHSVM/sourcecode/SnowStats.c
+++ b/DHSVM/sourcecode/SnowStats.c
@@ -1,0 +1,76 @@
+/*
+ * SUMMARY:      SnowStats.c - calculate snow stats
+ * USAGE:        Part of DHSVM
+ *
+ * AUTHOR:       Zhuoran Duan
+ * ORG:          Pacific Northwest National Laboratory
+ * E-MAIL:       zhuoran.duan@pnnl.gov
+ * ORIG-DATE:    Jul-2019
+ * DESCRIPTION:  Calculate the values for the snow 
+ *               state variables over the basin.
+ * DESCRIP-END.
+ * FUNCTIONS:    SnowStats()
+ * COMMENTS:
+ * 
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "settings.h"
+#include "data.h"
+#include "DHSVMerror.h"
+#include "functions.h"
+#include "constants.h"
+
+/*****************************************************************************
+  SnowStats()
+  
+  Calculate the statistics for SWE analysis (peak, peak date, melt out date).  
+ 
+  The intial values are set to zero in the function InitNewYear on very first 
+  timestep of a new water year.
+
+  Dates were converted to unsigned int in format of YYYYMMDD.
+*****************************************************************************/
+void SnowStats(DATE *Now, MAPSIZE *Map, OPTIONSTRUCT *Options, 
+        TOPOPIX **TopoMap, SNOWPIX **Snow, int Dt)
+{
+  int x;
+  int y;
+  int DNum; 
+  //printf("updating SWE stats map\n");
+ 
+  DNum = Now->Year * 10000 + Now->Month * 100 + Now->Day;
+  // printf("currnet year %d \n", Now->Year);
+  // printf("currnet month is %d \n", Now->Month);
+  // printf("currnet day is %d \n", Now->Day);
+  // printf("currnet DNum is %d \n", DNum);
+  for (y = 0; y < Map->NY; y++) {
+    for (x = 0; x < Map->NX; x++) {
+      if (INBASIN(TopoMap[y][x].Mask)) {
+           //printf("currnet SWE is %f \n", Snow[y][x].Swq);
+          // Update Peak SWE and Peak SWE date
+          if ( Snow[y][x].Swq > Snow[y][x].MaxSwe){
+            Snow[y][x].MaxSwe = Snow[y][x].Swq;
+            Snow[y][x].MaxSweDate = DNum; 
+            /* When the MaxSwe is updated, reset the melt out date to 0 so that it
+            overwrites previous in-corret dates*/
+            Snow[y][x].MeltOutDate = 0; 
+          }
+
+          // Update Peak SWE Date
+          /* Criteria :
+            1. If snow < 5mm
+            2. First date past the peak SWE date
+            3. And Preceding 7/15 day has snow  //for now this was not implimented
+          */
+         if ((Snow[y][x].Swq < MIN_SWE) && (DNum > Snow[y][x].MaxSweDate) && (Snow[y][x].MeltOutDate == 0)){
+            Snow[y][x].MeltOutDate = DNum;    
+            printf("SWE Melt out date is %d \n", Snow[y][x].MeltOutDate);
+            }
+      }
+    }
+  }
+}

--- a/DHSVM/sourcecode/VarID.c
+++ b/DHSVM/sourcecode/VarID.c
@@ -165,6 +165,15 @@ struct {
   411, "Snow.Albedo",
       "Snow Albedo", "%.4g",
       " ", "Albedo of snow pack surface", NC_FLOAT, FALSE, FALSE, FALSE, 0 }, {
+  412, "Snow.MaxSwe",
+      "Peak SWE", "%.4g",
+      " ", "Peak SWE of current water year", NC_FLOAT, FALSE, FALSE, FALSE, 0 }, {
+  413, "Snow.MaxSweDate",
+      "Peak SWE Date", "%d",
+      " ", "Peak SWE Date of current water year", NC_INT, FALSE, FALSE, FALSE, 0 }, {
+  414, "Snow.MeltOutDate",
+      "Melt out date", "%d",
+      " ", "Snow disappearance date of current water year", NC_INT, FALSE, FALSE, FALSE, 0 }, {
   501, "Soil.Moist",
       "Soil Moisture Content", "%.4g",
       "", "Soil moisture for layer %d", NC_FLOAT, TRUE, FALSE, TRUE, 0}, {

--- a/DHSVM/sourcecode/data.h
+++ b/DHSVM/sourcecode/data.h
@@ -248,6 +248,7 @@ typedef struct {
   int CanopyGapping;            /* if canopy gapping is on */
   int SnowSlide;                /* if snow sliding option is true */
   int PrecipSepr;               /* if TRUE use separate input of rain and snow */
+  int SnowStats;               /* if TRUE dumps snow statistics for each water year */
   char PrismDataPath[BUFSIZE + 1];
   char PrismDataExt[BUFSIZE + 1];
   char ShadingDataPath[BUFSIZE + 1];
@@ -373,6 +374,11 @@ typedef struct {
 
   float Freeze;			/* albedo when surface temperature below 0 C */
   float Thaw;			/* albedo when surface temperature above 0 C */
+
+  // SWE stats 
+  float MaxSwe;         /*Peak SWE of the water year*/
+  unint MaxSweDate;       /*Peak SWE date/timestep of the water year*/
+  unint MeltOutDate;    /* Last day of SWE of the water year */
 } SNOWPIX;
 
 typedef struct {

--- a/DHSVM/sourcecode/functions.h
+++ b/DHSVM/sourcecode/functions.h
@@ -190,7 +190,10 @@ void InitNewStep(INPUTFILES *InFiles, MAPSIZE *Map, TIMESTRUCT *Time,
 		 RADARPIX **RadarMap, SOLARGEOMETRY *SolarGeo, 
 		 TOPOPIX **TopoMap, SOILPIX **SoilMap, float ***MM5Input, 
                  float **PrecipLapseMap, float ***WindModel, MAPSIZE *MM5Map);
-                 
+
+void InitNewWaterYear(TIMESTRUCT *Time, OPTIONSTRUCT *Options, MAPSIZE *Map,
+                TOPOPIX **TopoMap, SNOWPIX **SnowMap);
+
 void InitParameterMaps(OPTIONSTRUCT *Options, MAPSIZE *Map, int Id,
   char *FileName, SNOWPIX ***SnowMap, int ParamType, float temp);
 
@@ -353,6 +356,9 @@ void StoreModelState(char *Path, DATE *Current, MAPSIZE *Map,
              SNOWPIX **SnowMap, MET_MAP_PIX **MetMap, VEGPIX **VegMap, 
              LAYER *Veg, SOILPIX **SoilMap, LAYER *Soil, ROADSTRUCT **Network, 
 		     UNITHYDRINFO *HydrographInfo, float *Hydrograph, CHANNEL *ChannelData);
+
+void SnowStats(DATE *Now, MAPSIZE *Map, OPTIONSTRUCT *Options, 
+        TOPOPIX **TopoMap, SNOWPIX **Snow, int Dt);
 
 float viscosity(float Tair, float Rh);
 

--- a/DHSVM/sourcecode/makefile_for_binary
+++ b/DHSVM/sourcecode/makefile_for_binary
@@ -27,7 +27,8 @@ SoilEvaporation.o StabilityCorrection.o StoreModelState.o	     \
 SurfaceEnergyBalance.o UnsaturatedFlow.o VarID.o WaterTableDepth.o  \
 channel.o channel_grid.o equal.o errorhandler.o globals.o tableio.o \
 channel_complt.o RiparianShading.o CanopyGapEnergyBalance.o deg2utm.o \
-CanopyGapRadiation.o Avalanche.o DistributeSatflow.o InitParameterMaps.o
+CanopyGapRadiation.o Avalanche.o DistributeSatflow.o InitParameterMaps.o\
+SnowStats.o
 
 SRCS = $(OBJS:%.o=%.c)
 

--- a/DHSVM/sourcecode/makefile_for_netcdf
+++ b/DHSVM/sourcecode/makefile_for_netcdf
@@ -25,7 +25,8 @@ SlopeAspect.o SnowInterception.o SnowMelt.o SnowPackEnergyBalance.o  \
 SoilEvaporation.o StabilityCorrection.o StoreModelState.o	      \
 SurfaceEnergyBalance.o UnsaturatedFlow.o VarID.o WaterTableDepth.o   \
 channel.o channel_grid.o equal.o errorhandler.o globals.o tableio.o  \
-channel_complt.o RiparianShading.o DistributeSatflow.o InitParameterMaps.o
+channel_complt.o RiparianShading.o DistributeSatflow.o InitParameterMaps.o\
+SnowStats.o
 
 SRCS = $(OBJS:%.o=%.c)
 

--- a/DHSVM/sourcecode/settings.h
+++ b/DHSVM/sourcecode/settings.h
@@ -104,6 +104,8 @@ typedef unsigned int unint;
 #define MAP_OUTPUT 1
 #define IMAGE_OUTPUT 2
 
+#define MIN_SWE 0.005 
+
 // Canopy type used in canopy gapping option
 enum CanopyType {
   Opening,
@@ -118,6 +120,7 @@ enum KEYS {
   temp_lapse, precip_lapse, cressman_radius, cressman_stations, prism_data_path, 
   prism_data_ext, shading_data_path, shading_data_ext, skyview_data_path, 
   stream_temp, canopy_shading, improv_radiation, gapping, snowslide, sepr, 
+  snowstats, 
   /* Area */
   coordinate_system, extreme_north, extreme_west, center_latitude,
   center_longitude, time_zone_meridian, number_of_rows,


### PR DESCRIPTION
… disappearance date

SWE stats for each water year. If set to "TRUE" then model will calculate swe stats along the run. For map export, users needs to specify variables and dump dates in the model maps section. Best to use last day of water year as dump date.