### PR TITLE
Resolves #27: Changes to MM5 terrain and temperature lapse

### DIFF
--- a/DHSVM/sourcecode/FinalMassBalance.c
+++ b/DHSVM/sourcecode/FinalMassBalance.c
@@ -78,7 +78,7 @@ void FinalMassBalance(FILES *Out, AGGREGATED *Total, WATERBALANCE *Mass)
   fprintf(stderr, "\n          Final Road Surface .....        %.3f\n", Total->Road.IExcess*1000);
   fprintf(stderr, "\n  Mass added to glacier ..........        %.3f\n", Total->Snow.Glacier*1000);
   fprintf(stderr, "  ******************************************************");
-  fprintf(stderr, "\n  Mass Error (mm).................        %.3f", MassError*1000);
+  fprintf(stderr, "\n  Mass Error (mm).................        %.3f\n", MassError*1000);
   
     /* Print the runoff final balance results to the output file named final.mass.balance */
   fprintf(Out->FilePtr, "\n  ********************************               Depth");
@@ -102,7 +102,7 @@ void FinalMassBalance(FILES *Out, AGGREGATED *Total, WATERBALANCE *Mass)
   fprintf(Out->FilePtr, "\n          Final Road Surface .....        %.3f\n", Total->Road.IExcess*1000);
   fprintf(Out->FilePtr, "\n  Mass added to glacier ..........        %.3f\n", Total->Snow.Glacier*1000);
   fprintf(Out->FilePtr, "  ******************************************************");
-  fprintf(Out->FilePtr, "\n  Mass Error (mm).................        %.3f", MassError*1000);
+  fprintf(Out->FilePtr, "\n  Mass Error (mm).................        %.3f\n", MassError*1000);
   
      /* error check: negative soil moisture and surface ponding */
   if (Total->SoilWater + Total->Soil.SatFlow < 0) {

--- a/DHSVM/sourcecode/InitConstants.c
+++ b/DHSVM/sourcecode/InitConstants.c
@@ -385,13 +385,20 @@ void InitConstants(LISTPTR Input, OPTIONSTRUCT *Options, MAPSIZE *Map,
   else
     ReportError(StrEnv[rhoverride].KeyName, 51);
 
+  /* Determine the type of temperature lapse rate */
+  if (strncmp(StrEnv[temp_lapse].VarStr, "CONSTANT", 8) == 0)
+    Options->TempLapse = CONSTANT;
+  else if (strncmp(StrEnv[temp_lapse].VarStr, "VARIABLE", 8) == 0)
+    Options->TempLapse = VARIABLE;
+  else
+    ReportError(StrEnv[temp_lapse].KeyName, 51);
+
 
   /* The other met options are only of importance if MM5 is FALSE */
   if (Options->MM5 == TRUE) {
     Options->PrecipType = NOT_APPLICABLE;
     Options->WindSource = NOT_APPLICABLE;
     Options->PrecipLapse = NOT_APPLICABLE;
-    Options->TempLapse = NOT_APPLICABLE;
     if (Options->QPF == TRUE)
       Options->PrecipType = STATION;
     if (Options->QPF == TRUE && Options->Prism == FALSE)
@@ -413,14 +420,6 @@ void InitConstants(LISTPTR Input, OPTIONSTRUCT *Options, MAPSIZE *Map,
       Options->WindSource = STATION;
     else
       ReportError(StrEnv[wind_source].KeyName, 51);
-
-    /* Determine the type of temperature lapse rate */
-    if (strncmp(StrEnv[temp_lapse].VarStr, "CONSTANT", 8) == 0)
-      Options->TempLapse = CONSTANT;
-    else if (strncmp(StrEnv[temp_lapse].VarStr, "VARIABLE", 8) == 0)
-      Options->TempLapse = VARIABLE;
-    else
-      ReportError(StrEnv[temp_lapse].KeyName, 51);
 
     /* Determine the type of precipitation lapse rate */
     if (strncmp(StrEnv[precip_lapse].VarStr, "CONSTANT", 8) == 0)

--- a/DHSVM/sourcecode/InitMetSources.c
+++ b/DHSVM/sourcecode/InitMetSources.c
@@ -426,7 +426,7 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
     {"METEOROLOGY", "MM5 PRECIPITATION FILE", "", ""},
     {"METEOROLOGY", "MM5 TERRAIN FILE", "", ""},
     {"METEOROLOGY", "MM5 TEMP LAPSE FILE", "", "none"},
-    /* {"METEOROLOGY", "MM5 TEMP LAPSE FREQUENCY", "", "single"}, */
+    {"METEOROLOGY", "MM5 TEMP LAPSE FREQUENCY", "", "single"},
     {"METEOROLOGY", "MM5 ROWS", "", ""},
     {"METEOROLOGY", "MM5 COLS", "", ""},
     {"METEOROLOGY", "MM5 EXTREME NORTH", "", ""},
@@ -458,14 +458,28 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
   strcpy(InFiles->MM5Terrain, StrEnv[MM5_terrain].VarStr);
 
   if (strncmp(StrEnv[MM5_lapse].VarStr, "none", 4)) {
+
     strncpy(InFiles->MM5Lapse, StrEnv[MM5_lapse].VarStr, BUFSIZE);
+
+    CopyLCase(VarStr, StrEnv[MM5_lapse_freq].VarStr, BUFSIZE + 1);
+
+    if (!strncmp(VarStr, "single", 6)) {
+      InFiles->MM5LapseFreq = FreqSingle;
+    } else if (!strncmp(VarStr, "month", 6)) {
+      InFiles->MM5LapseFreq = FreqMonth;
+    } else if (!strncmp(VarStr, "continuous", 10)) {
+      InFiles->MM5LapseFreq = FreqContinous;
+    } else {
+      ReportError(StrEnv[MM5_lapse_freq].VarStr, 70);
+    }
+    
   } else {
     strcpy(InFiles->MM5Lapse, "");
     if (Options->TempLapse != CONSTANT) {
       ReportError(StrEnv[MM5_lapse].VarStr, 51);
     }
   }
-  
+
   if (IsEmptyStr(StrEnv[MM5_lapse].VarStr))
     ReportError(StrEnv[MM5_lapse].KeyName, 51);
 

--- a/DHSVM/sourcecode/InitMetSources.c
+++ b/DHSVM/sourcecode/InitMetSources.c
@@ -461,6 +461,9 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
     strncpy(InFiles->MM5Lapse, StrEnv[MM5_lapse].VarStr, BUFSIZE);
   } else {
     strcpy(InFiles->MM5Lapse, "");
+    if (Options->TempLapse != CONSTANT) {
+      ReportError(StrEnv[MM5_lapse].VarStr, 51);
+    }
   }
   
   if (IsEmptyStr(StrEnv[MM5_lapse].VarStr))

--- a/DHSVM/sourcecode/InitMetSources.c
+++ b/DHSVM/sourcecode/InitMetSources.c
@@ -425,7 +425,8 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
     {"METEOROLOGY", "MM5 LONGWAVE FILE", "", ""},
     {"METEOROLOGY", "MM5 PRECIPITATION FILE", "", ""},
     {"METEOROLOGY", "MM5 TERRAIN FILE", "", ""},
-    {"METEOROLOGY", "MM5 TEMP LAPSE FILE", "", ""},
+    {"METEOROLOGY", "MM5 TEMP LAPSE FILE", "", "none"},
+    /* {"METEOROLOGY", "MM5 TEMP LAPSE FREQUENCY", "", "single"}, */
     {"METEOROLOGY", "MM5 ROWS", "", ""},
     {"METEOROLOGY", "MM5 COLS", "", ""},
     {"METEOROLOGY", "MM5 EXTREME NORTH", "", ""},
@@ -456,9 +457,14 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
     ReportError(StrEnv[MM5_terrain].KeyName, 51);
   strcpy(InFiles->MM5Terrain, StrEnv[MM5_terrain].VarStr);
 
+  if (strncmp(StrEnv[MM5_lapse].VarStr, "none", 4)) {
+    strncpy(InFiles->MM5Lapse, StrEnv[MM5_lapse].VarStr, BUFSIZE);
+  } else {
+    strcpy(InFiles->MM5Lapse, "");
+  }
+  
   if (IsEmptyStr(StrEnv[MM5_lapse].VarStr))
     ReportError(StrEnv[MM5_lapse].KeyName, 51);
-  strcpy(InFiles->MM5Lapse, StrEnv[MM5_lapse].VarStr);
 
   if (IsEmptyStr(StrEnv[MM5_humidity].VarStr))
     ReportError(StrEnv[MM5_humidity].KeyName, 51);
@@ -573,7 +579,11 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
   printf("wind Map is %s\n", InFiles->MM5Wind);
   printf("shortwave Map is %s\n", InFiles->MM5ShortWave);
   printf("humidity Map is %s\n", InFiles->MM5Humidity);
-  printf("lapse Map is %s\n", InFiles->MM5Lapse);
+  if (strlen(InFiles->MM5Lapse) > 0) {
+    printf("lapse Map is %s\n", InFiles->MM5Lapse);
+  } else {
+    printf("temperature lapse rate is constant\n");
+  }
   printf("terrain Map is %s\n", InFiles->MM5Terrain);
   printf("MM5 offset x is %d \n", MM5Map->OffsetX);
   printf("MM5 offset y is %d \n", MM5Map->OffsetY);

--- a/DHSVM/sourcecode/InitNewMonth.c
+++ b/DHSVM/sourcecode/InitNewMonth.c
@@ -309,9 +309,19 @@ void InitNewStep(INPUTFILES *InFiles, MAPSIZE *Map, TIMESTRUCT *Time,
       UpdateMM5Field(InFiles->MM5Terrain, Step, Map, MM5Map, Array,
                      MM5Input[MM5_terrain - 1]);
     }
-    
-    UpdateMM5Field(InFiles->MM5Lapse, Step, Map, MM5Map, Array,
-                   MM5Input[MM5_lapse - 1]);
+
+    /* If a MM5 temperature lapse map is not specified, fill the map
+       with the domain-wide temperature lapse rate */
+    if (strlen(InFiles->MM5Lapse) > 0) {
+      UpdateMM5Field(InFiles->MM5Lapse, Step, Map, MM5Map, Array,
+                     MM5Input[MM5_lapse - 1]);
+    } else if (first) {
+      for (y = 0; y < Map->NY; y++) {
+        for (x = 0; x < Map->NX; x++) {
+          MM5Input[MM5_lapse - 1][y][x] = Options->TempLapse;
+        }
+      }
+    }
 
     if (Options->HeatFlux == TRUE) {
 

--- a/DHSVM/sourcecode/InitNewMonth.c
+++ b/DHSVM/sourcecode/InitNewMonth.c
@@ -322,7 +322,7 @@ void InitNewStep(INPUTFILES *InFiles, MAPSIZE *Map, TIMESTRUCT *Time,
     } else if (first) {
       for (y = 0; y < Map->NY; y++) {
         for (x = 0; x < Map->NX; x++) {
-          MM5Input[MM5_lapse - 1][y][x] = Options->TempLapse;
+          MM5Input[MM5_lapse - 1][y][x] = TEMPLAPSE;
         }
       }
     }

--- a/DHSVM/sourcecode/InitNewMonth.c
+++ b/DHSVM/sourcecode/InitNewMonth.c
@@ -256,8 +256,11 @@ void InitNewStep(INPUTFILES *InFiles, MAPSIZE *Map, TIMESTRUCT *Time,
   int Step;			/* Step in the MM5 Input */
   float *Array = NULL;
   int MM5Y, MM5X;
-  int rdprecip;
+  int rdprecip, rdstep;
+  uchar first;
   const int NumberType = NC_FLOAT;
+
+  first = IsEqualTime(&(Time->Current), &(Time->Start));
 
   /*printf("current time is %4d-%2d-%2d-%2d\n", Time->Current.Year,Time->Current.Month, Time->Current.Day, Time->Current.Hour);*/
 
@@ -305,8 +308,9 @@ void InitNewStep(INPUTFILES *InFiles, MAPSIZE *Map, TIMESTRUCT *Time,
 
     /* Terrain does not change during the simulation, so only read it
        at step 0 */
-    if (Step == 0) {
-      UpdateMM5Field(InFiles->MM5Terrain, Step, Map, MM5Map, Array,
+    if (first) {
+      rdstep = 0;
+      UpdateMM5Field(InFiles->MM5Terrain, rdstep, Map, MM5Map, Array,
                      MM5Input[MM5_terrain - 1]);
     }
     
@@ -333,15 +337,19 @@ void InitNewStep(INPUTFILES *InFiles, MAPSIZE *Map, TIMESTRUCT *Time,
 
       switch (InFiles->MM5PrecipDistFreq) {
       case (FreqSingle):
-        if (Step == 0) rdprecip = 1;
+        if (first) {
+          rdprecip = 1;
+          rdstep = 0;
+        }
         break;
       case (FreqMonth):
-        Step = Time->Current.Month - 1;
+        rdstep = Time->Current.Month - 1;
         rdprecip = 1;
         break;
       case (FreqContinous):
         /* Step unchanged */
         rdprecip = 1;
+        rdstep = Step;
         break;
       default:
         ReportError("InitNewStep", 15);
@@ -353,7 +361,7 @@ void InitNewStep(INPUTFILES *InFiles, MAPSIZE *Map, TIMESTRUCT *Time,
           ReportError((char *)Routine, 1);
         
         
-        Read2DMatrix(InFiles->PrecipLapseFile, Array, NumberType, Map, Step, "", 0);
+        Read2DMatrix(InFiles->PrecipLapseFile, Array, NumberType, Map, rdstep, "", 0);
         for (y = 0; y < Map->NY; y++) {
           for (x = 0; x < Map->NX; x++) {
             PrecipLapseMap[y][x] = Array[y * Map->NX + x];

--- a/DHSVM/sourcecode/data.h
+++ b/DHSVM/sourcecode/data.h
@@ -109,6 +109,7 @@ typedef struct {
   char MM5Precipitation[BUFSIZE + 1];	/* File with MM5 precipitation 
 					   (m/timestep) */
   char **MM5SoilTemp;		/* Files with MM5 soil temperatures (C) */
+  MM5FREQ MM5LapseFreq;         /* Frequency of MM5 temperature lapse maps */
   MM5FREQ MM5PrecipDistFreq;    /* Frequency of MM5 precip distribution maps */
   char PrecipLapseFile[BUFSIZE + 1];	/* File with precipitation 
 					   lapse rate map */

--- a/DHSVM/sourcecode/settings.h
+++ b/DHSVM/sourcecode/settings.h
@@ -154,7 +154,7 @@ enum KEYS {
   precip_lapse_rate_file = 0,
   /* MM5 information */
   MM5_start = 0, MM5_temperature, MM5_humidity, MM5_wind, MM5_shortwave,
-  MM5_longwave, MM5_precip, MM5_terrain, MM5_lapse,
+  MM5_longwave, MM5_precip, MM5_terrain, MM5_lapse, MM5_lapse_freq,
   MM5_rows, MM5_cols, MM5_ext_north, MM5_ext_west, MM5_dy, MM5_precip_dist, MM5_precip_freq,
   /* grid information */
   grid_ext_north=0, grid_ext_south, grid_ext_east, grid_ext_west, tot_grid, decim,


### PR DESCRIPTION
MM5 terrain map is assumed constant and only read once.
MM5 temperature lapse map is now optional. If not specified, the lapse rate from `[CONSTANTS]` is used domain-wide. Like precipitation distribution, the MM5 temperature lapse rate map can be `Single`, `Month`, or `Continuous`.