### PR TITLE
Add CMake configuration option for 8-neighbor routing scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 # DESCRIP-END.
 # COMMENTS:
 #
-# Last Change: 2018-03-30 08:34:35 d3g096
+# Last Change: 2019-10-08 08:43:52 d3g096
 
 # -------------------------------------------------------------
 # General set up
@@ -26,6 +26,11 @@ list (APPEND CMAKE_MODULE_PATH "${DHSVM_SOURCE_DIR}/cmake")
 # -------------------------------------------------------------
 
 enable_language(C)
+
+# Option to set the surface/subsurface drainage direction
+option(DHSVM_D8
+  "Switch surface/subsurface drainage algorithm to 8-neighbor steepest descent"
+  OFF)
 
 # Option to dump topography maps, for debugging
 option (DHSVM_DUMP_TOPO

--- a/DHSVM/sourcecode/CMakeLists.txt
+++ b/DHSVM/sourcecode/CMakeLists.txt
@@ -9,7 +9,7 @@
 # DESCRIP-END.
 # COMMENTS:
 #
-# Last Change: 2019-08-22 06:00:50 d3g096
+# Last Change: 2019-10-08 08:44:21 d3g096
 
 # -------------------------------------------------------------
 # Set up for this subdirectory
@@ -25,6 +25,15 @@ include_directories(BEFORE
 if (DHSVM_DUMP_TOPO)
   add_definitions(-DTOPO_DUMP)
 endif (DHSVM_DUMP_TOPO)
+
+if (DHSVM_D8)
+  add_definitions(-DNDIRS=8)
+endif(DHSVM_D8)
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    message("debug mode: turning DEBUG messages on")
+    add_definitions(-DDEBUG=1)
+endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 # tablio.c generation
 if (FLEX_FOUND)

--- a/DHSVM/sourcecode/ExecDump.c
+++ b/DHSVM/sourcecode/ExecDump.c
@@ -1343,6 +1343,9 @@ DumpTopo(MAPSIZE *Map, TOPOPIX **TopoMap)
   float *Array;
   int numPoints;
   char FileName[BUFSIZE + 1];
+  MAPDUMP DMap;
+
+  DMap.Resolution = MAP_OUTPUT;
 
   numPoints = Map->NX*Map->NY;
 
@@ -1360,7 +1363,10 @@ DumpTopo(MAPSIZE *Map, TOPOPIX **TopoMap)
       }
     }
   }
-  Write2DMatrix(FileName, Array, NC_FLOAT, Map, NULL, 0);
+  DMap.ID = 001;
+  GetVarAttr(&DMap);
+  CreateMapFile(FileName, "DEM", Map);
+  Write2DMatrix(FileName, Array, NC_FLOAT, Map, &DMap, 0);
 
   sprintf(FileName, "%s%s", "Slope", fileext);
   for (y = 0; y < Map->NY; y++) {
@@ -1373,7 +1379,10 @@ DumpTopo(MAPSIZE *Map, TOPOPIX **TopoMap)
       }
     }
   }
-  Write2DMatrix(FileName, Array, NC_FLOAT, Map, NULL, 0);
+  DMap.ID = 020;
+  GetVarAttr(&DMap);
+  CreateMapFile(FileName, "Slope", Map);
+  Write2DMatrix(FileName, Array, NC_FLOAT, Map, &DMap, 0);
 
 
   sprintf(FileName, "%s%s", "Mask", fileext);
@@ -1387,7 +1396,11 @@ DumpTopo(MAPSIZE *Map, TOPOPIX **TopoMap)
       }
     }
   }
-  Write2DMatrix(FileName, Array, NC_FLOAT, Map, NULL, 0);
+  DMap.ID = 002;
+  GetVarAttr(&DMap);
+  DMap.NumberType = NC_FLOAT;
+  CreateMapFile(FileName, "Basin mask", Map);
+  Write2DMatrix(FileName, Array, NC_FLOAT, Map, &DMap, 0);
 
   sprintf(FileName, "%s%s", "Aspect", fileext);
   for (y = 0; y < Map->NY; y++) {
@@ -1400,7 +1413,10 @@ DumpTopo(MAPSIZE *Map, TOPOPIX **TopoMap)
       }
     }
   }
-  Write2DMatrix(FileName, Array, NC_FLOAT, Map, NULL, 0);
+  DMap.ID = 021;
+  GetVarAttr(&DMap);
+  CreateMapFile(FileName, "Aspect", Map);
+  Write2DMatrix(FileName, Array, NC_FLOAT, Map, &DMap, 0);
 
   sprintf(FileName, "%s%s", "TotalDir", fileext);
   for (y = 0; y < Map->NY; y++) {
@@ -1413,10 +1429,14 @@ DumpTopo(MAPSIZE *Map, TOPOPIX **TopoMap)
       }
     }
   }
-  Write2DMatrix(FileName, Array, NC_FLOAT, Map, NULL, 0);
+  DMap.ID = 022;
+  GetVarAttr(&DMap);
+  CreateMapFile(FileName, "Flow directions", Map);
+  Write2DMatrix(FileName, Array, NC_FLOAT, Map, &DMap, 0);
 
   for (k = 0; k < NDIRS; k++) {
-    sprintf(FileName, "%s%d%s", "Dir", k, fileext);
+    sprintf(DMap.Name, "Dir%d", k);
+    sprintf(DMap.LongName, "Flow in direction %d", k);
     for (y = 0; y < Map->NY; y++) {
       for (x = 0; x < Map->NX; x++) {
         if (INBASIN(TopoMap[y][x].Mask)) {
@@ -1427,7 +1447,7 @@ DumpTopo(MAPSIZE *Map, TOPOPIX **TopoMap)
         }
       }
     }
-    Write2DMatrix(FileName, Array, NC_FLOAT, Map, NULL, 0);
+    Write2DMatrix(FileName, Array, NC_FLOAT, Map, &DMap, 0);
   }
 
 

--- a/DHSVM/sourcecode/VarID.c
+++ b/DHSVM/sourcecode/VarID.c
@@ -79,6 +79,15 @@ struct {
   013, "Soil.Porosity",
        "Soil Porosity", "%.3f", 
        "", "Soil Porosity", NC_FLOAT, TRUE, FALSE, FALSE, 0 },{  
+  020, "Basin.Slope",
+       "Slope", "%.4f",
+       "none", "Land surface slope", NC_FLOAT, FALSE, FALSE, FALSE, 0}, {
+  021, "Basin.Aspect",
+       "Aspect", "%.3f",
+       "degrees", "Aspect", NC_FLOAT, FALSE, FALSE, FALSE, 0}, {
+  022, "Basin.FlowDir",
+       "FlowDir", "%.0f",
+       "none", "FlowDir", NC_FLOAT, FALSE, FALSE, FALSE, 0}, {
   100, "Met.PrecipMultiplier",
 	   "PptMultiplier", "%.8f",
 	   "", "Precipitation Multiplier", NC_FLOAT, FALSE, FALSE, FALSE, 0 },{

--- a/DHSVM/sourcecode/VarID.c
+++ b/DHSVM/sourcecode/VarID.c
@@ -76,7 +76,7 @@ struct {
   012, "Soil.KsLat",
        "Soil Lateral Conductivity", "%.6f", 
        "", "Soil Lateral Conductivity", NC_FLOAT, FALSE, FALSE, FALSE, 0 },{
-  013, "Soil.Porostity",
+  013, "Soil.Porosity",
        "Soil Porosity", "%.3f", 
        "", "Soil Porosity", NC_FLOAT, TRUE, FALSE, FALSE, 0 },{  
   100, "Met.PrecipMultiplier",

--- a/DHSVM/sourcecode/settings.h
+++ b/DHSVM/sourcecode/settings.h
@@ -93,7 +93,14 @@ typedef unsigned int unint;
 #define MAXSTRING    255
 #define NAMESIZE     127
 
-#define NDIRS          4	/* Number of directions in which water can flow, must equal 4 */
+#if !defined(NDIRS)
+#define NDIRS          4        /* Number of directions in which water can flow, must equal 4 */
+#endif
+
+#if !((NDIRS == 4) || (NDIRS == 8))
+#error "NDIRS must be 4 or 8"
+#endif
+
 #define NNEIGHBORS     8    /* Number of directions in which water can flow based on fine grid, must equal 8 */
 
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ select optional features.  Here are some terse instructions:
 The original Makefiles are in the source tree and can still be used as
 described in the tutorial if preferred.
 
+### Experimental Surface/Subsurface Mode ###
+
+The normal DHSVM surface/subsurface routing scheme uses 4 neighbors
+and directs cell outflow to all down-gradient neighbors ("D4").  Another
+method, which uses 8 neighbors and directs outflow only to the
+neighbor with the steepest gradient ("D8").  The latter has proved useful
+in very low-gradient areas that span several cells.  To enable D8
+routing add this option
+
+    -D DHSVM_D8:BOOL=ON
+    
+to the configuration. D4 is the default.  
+
 ### Snow-only mode ###
 
 If DHSVM is configured with this option,

--- a/example_configuration.sh
+++ b/example_configuration.sh
@@ -10,22 +10,23 @@
 # DESCRIP-END.
 # COMMENTS:
 #
-# Last Change: 2019-10-08 08:43:02 d3g096
+# Last Change: 2019-10-08 08:45:26 d3g096
 
 set -xue
 
 # -------------------------------------------------------------
 # handle command line options
 # -------------------------------------------------------------
-usage="$0 [-d|-r] [name]"
+usage="$0 [-d|-r] [-8] [-t] [name]"
 
-opts=`getopt drt8 $*`
+opts=`getopt dr8 $*`
 if [ $? != 0 ]; then
     echo $usage >&2
     exit 2
 fi
 set -- $opts
 
+d8="OFF"
 build="RelWithDebInfo"
 for o in $*; do
     case $o in
@@ -35,6 +36,10 @@ for o in $*; do
             ;;
         -r)
             build="Release"
+            shift
+            ;;
+        -8)
+            d8="ON"
             shift
             ;;
         --)

--- a/example_configuration.sh
+++ b/example_configuration.sh
@@ -10,7 +10,7 @@
 # DESCRIP-END.
 # COMMENTS:
 #
-# Last Change: 2019-10-08 08:45:26 d3g096
+# Last Change: 2019-10-08 13:28:20 d3g096
 
 set -xue
 
@@ -70,7 +70,6 @@ common_flags="\
         -D DHSVM_BUILD_TESTS:BOOL=OFF \
         -D DHSVM_USE_RBM:BOOL=ON \
         -D DHSVM_DUMP_TOPO:BOOL=ON \
-	-D DHSVM_USE_GPTL:BOOL=$timing \
         -D DHSVM_D8:BOOL=$d8 \
         -D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
 "

--- a/example_configuration.sh
+++ b/example_configuration.sh
@@ -10,7 +10,7 @@
 # DESCRIP-END.
 # COMMENTS:
 #
-# Last Change: 2018-03-30 08:34:41 d3g096
+# Last Change: 2019-10-08 08:43:02 d3g096
 
 set -xue
 
@@ -19,11 +19,12 @@ set -xue
 # -------------------------------------------------------------
 usage="$0 [-d|-r] [name]"
 
-set -- `getopt d $*`
+opts=`getopt drt8 $*`
 if [ $? != 0 ]; then
     echo $usage >&2
     exit 2
 fi
+set -- $opts
 
 build="RelWithDebInfo"
 for o in $*; do
@@ -61,8 +62,12 @@ options="-Wdev --debug-trycompile"
 common_flags="\
         -D CMAKE_BUILD_TYPE:STRING=$build \
         -D DHSVM_SNOW_ONLY:BOOL=ON \
-        -D DHSVM_BUILD_TESTS:BOOL=ON \
-        -D DHSVM_DUMP_TOPO:BOOL=OFF \
+        -D DHSVM_BUILD_TESTS:BOOL=OFF \
+        -D DHSVM_USE_RBM:BOOL=ON \
+        -D DHSVM_DUMP_TOPO:BOOL=ON \
+	-D DHSVM_USE_GPTL:BOOL=$timing \
+        -D DHSVM_D8:BOOL=$d8 \
+        -D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
 "
 
 if [ $host == "flophouse" ]; then


### PR DESCRIPTION
I added a cmake configuration option the 8-neighbor routing scheme.  If `-D DHSVM_D8:BOOL=ON` is specified, DHSVM is built with the 8-neighbor scheme instead of the default 4-neighbor.  