### PR TITLE
Parallel: make Avalanche() parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,63 +1,64 @@
-i#OS junk files
 
-[Tt]humbs.db
-*.DS_Store
 
+
+
+
+
+
+
+#*.bin
+#*txt
+#INPUT.*
+#Project files
+#Subversion files
+#Tooling
 #Visual Studio files
-*.o
+#input file
+#input/
+#modelstate/
+#output file
+**/program/
+*.DS_Store
+*.[Cc]ache
 *.[Oo]bj
-*.user
 *.aps
-*.pch
-*.vspscc
-*.vssscc
-*_i.c
-*_p.c
+*.bak
+*.ilk
+*.lib
+*.log
 *.ncb
+*.o
+*.pch
+*.pyc
+*.resharper
+*.sbr
+*.sdf
 *.suo
 *.tlb
 *.tlh
-*.bak
-*.[Cc]ache
-*.ilk
-*.log
-*.lib
-*.sbr
-*.sdf
-*.pyc
+*.user
+*.vspscc
+*.vssscc
 *.xml
 *NARR_Morr*
-ipch/
-obj/
-[Bb]in
-[Dd]ebug*/
-[Rr]elease*/
-Ankh.NoLoad
-#Tooling
-_ReSharper*/
-*.resharper
-[Tt]est[Rr]esult*
-
-#Project files
-[Bb]uild/
-
-#Subversion files
-.svn
-
-#output file
-output/
+*_i.c
+*_p.c
 *develop/
 *gitignore
-
-program/
-**/program/
+.svn
+/build.tlaloc
+Ankh.NoLoad
 DHSVM3.2
-
-#input file
-#INPUT.*
-#modelstate/
-#input/
-#*.bin
-#*txt
-
+[Bb]in
+[Bb]uild/
+[Dd]ebug*/
+[Rr]elease*/
+[Tt]est[Rr]esult*
+[Tt]humbs.db
+_ReSharper*/
 gitignore
+i#OS junk files
+ipch/
+obj/
+output/
+program/

--- a/DHSVM/sourcecode/CalcWeights.c
+++ b/DHSVM/sourcecode/CalcWeights.c
@@ -274,8 +274,8 @@ void CalcWeights(METLOCATION * Station, int NStats, int NX, int NY,
         }
 
         if (totalweight < 250 || totalweight > 260)
-          printf("error in interpolation weight at pixel y %d x %d : %d \n", y,
-            x, totalweight);
+          /*printf("error in interpolation weight at pixel y %d x %d : %d \n", y,
+            x, totalweight); */
         stat[tempid] += 1;
       }
 

--- a/DHSVM/sourcecode/InitMetSources.c
+++ b/DHSVM/sourcecode/InitMetSources.c
@@ -32,7 +32,7 @@
 #include "getinit.h"
 #include "constants.h"
 #include "rad.h"
-
+                          
  /*******************************************************************************
    Function name: InitMetSources()
 
@@ -238,7 +238,7 @@ void InitGridMet(OPTIONSTRUCT *Options, LISTPTR Input, MAPSIZE *Map,
   char tempfilename[BUFSIZE + 1];
   FILE *PrismStatFile;
   char junk[BUFSIZE + 1], infileformat[BUFSIZE + 1];
-  DIR *dir;
+  DIR *dir;                   
   struct dirent *ent;
 
   STRINIENTRY StrEnv[] = {
@@ -250,6 +250,7 @@ void InitGridMet(OPTIONSTRUCT *Options, LISTPTR Input, MAPSIZE *Map,
 	{ "METEOROLOGY", "GRID_DECIMAL", "", "" },
     { "METEOROLOGY", "MET FILE PATH", "", "" },
     { "METEOROLOGY", "FILE PREFIX", "", "" },
+    { "METEOROLOGY", "UTM ZONE", "", "" },                                      
     { NULL, NULL, "", NULL },
   };
 
@@ -300,6 +301,10 @@ void InitGridMet(OPTIONSTRUCT *Options, LISTPTR Input, MAPSIZE *Map,
     ReportError(StrEnv[file_prefix].KeyName, 51);
   strcpy(Grid->fileprefix, StrEnv[file_prefix].VarStr);
 
+  /* UTM zone used as reference for all spatial input files */
+  if (!CopyInt(&(Grid->utmzone), StrEnv[utm_zone].VarStr, 1))
+    ReportError(StrEnv[utm_zone].KeyName, 51);                                              
+
   /* Allocate memory for the stations */
   if (!(*Stat = (METLOCATION *)calloc(Grid->NGrids, sizeof(METLOCATION))))
     ReportError(Routine, 1);
@@ -314,7 +319,7 @@ void InitGridMet(OPTIONSTRUCT *Options, LISTPTR Input, MAPSIZE *Map,
   m = 0;
   if ((dir = opendir(Grid->filepath)) != NULL) {
     /* print all the files and directories within directory */
-    while ((ent = readdir(dir)) != NULL) {
+    while ((ent = readdir(dir)) != NULL) {                        
       if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, "..")) {
         continue;
       }
@@ -322,34 +327,34 @@ void InitGridMet(OPTIONSTRUCT *Options, LISTPTR Input, MAPSIZE *Map,
         sscanf(ent->d_name, junk, &lat, &lon);
 
         /* convert lat and lon to utm */
-        deg2utm(lat, lon, &East, &North);		
-	sprintf((*Stat)[k].Name, "data_%f_%f\n", lat, lon);
-	printf("data_%f_%f %f %f\n", lat, lon, East, North);
-	
-	(*Stat)[k].Loc.N = Round(((Map->Yorig - 0.5 * Map->DY) - North) / Map->DY);
+        deg2utm(lat, lon, &East, &North, Grid->utmzone);		
+		sprintf((*Stat)[k].Name, "data_%f_%f\n", lat, lon);
+    printf("%f, %f, %f, %f\n", lat, lon, East, North);
+		
+		(*Stat)[k].Loc.N = Round(((Map->Yorig - 0.5 * Map->DY) - North) / Map->DY);
         (*Stat)[k].Loc.E = Round((East - (Map->Xorig + 0.5 * Map->DX)) / Map->DX);
         m += 1;
 
         /* met grids must be with the bounding box of the basin */
 		if (((*Stat)[k].Loc.N >= Map->NY || (*Stat)[k].Loc.N < 0 ||
-          (*Stat)[k].Loc.E >= Map->NX || (*Stat)[k].Loc.E < 0)) {
-          //printf("..... Station %d outside the basin bounding box: %s ignored\n", m, (*Stat)[k].Name);
+          (*Stat)[k].Loc.E >= Map->NX || (*Stat)[k].Loc.E < 0)) {                                   
+          //printf("..... Station %d outside the basin bounding box: %s ignored\n", m, (*Stat)[k].Name);           
 		  k = k;
 		}
         else {
           /* only include grids within the mask */
           if (Options->Outside == FALSE) {
             if (INBASIN(TopoMap[(*Stat)[k].Loc.N][(*Stat)[k].Loc.E].Mask)) {
-              
+                                                                         
 			  /* open met data file */
               sprintf((*Stat)[k].MetFile.FileName, infileformat, Grid->filepath, Grid->fileprefix, lat, lon);
-
+                                                                  
               if (!((*Stat)[k].MetFile.FilePtr = fopen((*Stat)[k].MetFile.FileName, "r"))) {
                 printf("..... %s doesn't exist\n", (*Stat)[k].MetFile.FileName);
                 continue;
-              }
-              printf("..... Station %d: %s is selected\n", m, (*Stat)[k].Name);
-              k = k + 1;
+              }                                        
+              printf("..... Station %d: %s is selected\n", m, (*Stat)[k].Name);            
+              k = k + 1;             
             }
           }
           else {
@@ -357,8 +362,8 @@ void InitGridMet(OPTIONSTRUCT *Options, LISTPTR Input, MAPSIZE *Map,
               if (!((*Stat)[k].MetFile.FilePtr = fopen((*Stat)[k].MetFile.FileName, "r"))) {
                 //printf("..... %s doesn't exist\n", (*Stat)[k].MetFile.FileName);
                 continue;
-              }
-              printf("..... Station %d: %s is selected\n", m, (*Stat)[k].Name);
+              }                                        
+              printf("..... Station %d: %s is selected\n", m, (*Stat)[k].Name);               
               k = k + 1;
             }
           }
@@ -453,11 +458,11 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
   if (IsEmptyStr(StrEnv[MM5_temperature].VarStr))
     ReportError(StrEnv[MM5_temperature].KeyName, 51);
   strcpy(InFiles->MM5Temp, StrEnv[MM5_temperature].VarStr);
-
+                             
   if (IsEmptyStr(StrEnv[MM5_terrain].VarStr))
     ReportError(StrEnv[MM5_terrain].KeyName, 51);
   strcpy(InFiles->MM5Terrain, StrEnv[MM5_terrain].VarStr);
-
+                                
   if (strncmp(StrEnv[MM5_lapse].VarStr, "none", 4)) {
 
     strncpy(InFiles->MM5Lapse, StrEnv[MM5_lapse].VarStr, BUFSIZE);
@@ -487,23 +492,24 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
   if (IsEmptyStr(StrEnv[MM5_humidity].VarStr))
     ReportError(StrEnv[MM5_humidity].KeyName, 51);
   strcpy(InFiles->MM5Humidity, StrEnv[MM5_humidity].VarStr);
-
+                                 
   if (IsEmptyStr(StrEnv[MM5_wind].VarStr))
     ReportError(StrEnv[MM5_wind].KeyName, 51);
   strcpy(InFiles->MM5Wind, StrEnv[MM5_wind].VarStr);
+                             
 
   if (IsEmptyStr(StrEnv[MM5_shortwave].VarStr))
     ReportError(StrEnv[MM5_shortwave].KeyName, 51);
   strcpy(InFiles->MM5ShortWave, StrEnv[MM5_shortwave].VarStr);
-
+                                  
   if (IsEmptyStr(StrEnv[MM5_longwave].VarStr))
     ReportError(StrEnv[MM5_longwave].KeyName, 51);
   strcpy(InFiles->MM5LongWave, StrEnv[MM5_longwave].VarStr);
-
+                                 
   if (IsEmptyStr(StrEnv[MM5_precip].VarStr))
     ReportError(StrEnv[MM5_precip].KeyName, 51);
   strcpy(InFiles->MM5Precipitation, StrEnv[MM5_precip].VarStr);
-
+                                      
   /* Use PrecipLapseFile to store the name of the MM5 precip
      distribution map file. This avoids wholesale code changes. */
   if (strncmp(StrEnv[MM5_precip_dist].VarStr, "none", 4)) {
@@ -525,8 +531,8 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
   } else {
     strcpy(InFiles->PrecipLapseFile, "");
   }
-
-  if (Options->HeatFlux == TRUE) {
+                                   
+  if (Options->HeatFlux == TRUE) {                               
     if (!(InFiles->MM5SoilTemp = (char **)calloc(sizeof(char *), NSoilLayers)))
       ReportError(Routine, 1);
 
@@ -565,7 +571,7 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
 
   if (MM5Map->OffsetX > 0 || MM5Map->OffsetY < 0)
     ReportError("Input Options File", 31);
-
+                
   printf("MM5 extreme north / south is %f %f \n", MM5Map->Yorig,
     MM5Map->Yorig - MM5Map->NY * MM5Map->DY);
   printf("MM5 extreme west / east is %f %f\n", MM5Map->Xorig,
@@ -593,10 +599,11 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
     }
   } else {
     printf("Precip is distributed evenly within MM5 cell\n");
-  }
+  }                                                            
   printf("wind Map is %s\n", InFiles->MM5Wind);
   printf("shortwave Map is %s\n", InFiles->MM5ShortWave);
   printf("humidity Map is %s\n", InFiles->MM5Humidity);
+                                                         
   if (strlen(InFiles->MM5Lapse) > 0) {
     printf("lapse Map is %s\n", InFiles->MM5Lapse);
   } else {
@@ -615,6 +622,7 @@ void InitMM5(LISTPTR Input, int NSoilLayers, TIMESTRUCT *Time,
   printf("fail if %d > %d\n",
     (int)((Map->NX - MM5Map->OffsetX) * Map->DX / MM5Map->DY),
     MM5Map->NX);
+  
   if ((int)((Map->NY + MM5Map->OffsetY) * Map->DY / MM5Map->DY) > MM5Map->NY
     || (int)((Map->NX - MM5Map->OffsetX) * Map->DX / MM5Map->DY) >
     MM5Map->NX)
@@ -691,7 +699,7 @@ void InitRadar(LISTPTR Input, MAPSIZE * Map, TIMESTRUCT * Time,
     ReportError(StrEnv[radar_grid].KeyName, 51);
   Radar->DX = Radar->DY;
 
-  Radar->DXY = sqrt(Radar->DX * Radar->DX + Radar->DY * Radar->DY);
+  Radar->DXY = sqrt(Radar->DX * Radar->DX + Radar->DY * Radar->DY);     
   Radar->X = 0;
   Radar->Y = 0;
   Radar->OffsetX = Round(((float)(Radar->Xorig - Map->Xorig)) /

--- a/DHSVM/sourcecode/InitMetSources.c
+++ b/DHSVM/sourcecode/InitMetSources.c
@@ -323,9 +323,10 @@ void InitGridMet(OPTIONSTRUCT *Options, LISTPTR Input, MAPSIZE *Map,
 
         /* convert lat and lon to utm */
         deg2utm(lat, lon, &East, &North);		
-		sprintf((*Stat)[k].Name, "data_%f_%f\n", lat, lon);
-		
-		(*Stat)[k].Loc.N = Round(((Map->Yorig - 0.5 * Map->DY) - North) / Map->DY);
+	sprintf((*Stat)[k].Name, "data_%f_%f\n", lat, lon);
+	//printf("data_%f_%f %f %f\n", lat, lon, East, North);
+	
+	(*Stat)[k].Loc.N = Round(((Map->Yorig - 0.5 * Map->DY) - North) / Map->DY);
         (*Stat)[k].Loc.E = Round((East - (Map->Xorig + 0.5 * Map->DX)) / Map->DX);
         m += 1;
 

--- a/DHSVM/sourcecode/InitMetSources.c
+++ b/DHSVM/sourcecode/InitMetSources.c
@@ -324,7 +324,7 @@ void InitGridMet(OPTIONSTRUCT *Options, LISTPTR Input, MAPSIZE *Map,
         /* convert lat and lon to utm */
         deg2utm(lat, lon, &East, &North);		
 	sprintf((*Stat)[k].Name, "data_%f_%f\n", lat, lon);
-	//printf("data_%f_%f %f %f\n", lat, lon, East, North);
+	printf("data_%f_%f %f %f\n", lat, lon, East, North);
 	
 	(*Stat)[k].Loc.N = Round(((Map->Yorig - 0.5 * Map->DY) - North) / Map->DY);
         (*Stat)[k].Loc.E = Round((East - (Map->Xorig + 0.5 * Map->DX)) / Map->DX);

--- a/DHSVM/sourcecode/MainDHSVM.c
+++ b/DHSVM/sourcecode/MainDHSVM.c
@@ -166,6 +166,18 @@ int main(int argc, char **argv)
     printf("WARNING: USING SNOW ONLY MODULES (prescribed in makefile)!\n");
     printf("----------------------------------\n");
 #endif
+    switch (NDIRS) {
+    case (4):
+      printf("\nNOTE: Using default 4-neighbor routing scheme\n");
+      break;
+    case (8):
+      printf("\nWARNING: Using experimental 8-neighbor routing scheme\n");
+      break;
+    default:
+      printf("\nERROR: Unknown routing scheme using %d neighbors, you should stop now\n", NDIRS);
+      break;
+    }
+      
     printf("\nSTARTING INITIALIZATION PROCEDURES\n\n");
   }
 

--- a/DHSVM/sourcecode/SlopeAspect.c
+++ b/DHSVM/sourcecode/SlopeAspect.c
@@ -42,10 +42,18 @@
 
 /* These indices are so neighbors can be looked up quickly */
 int xdirection[NDIRS] = {
+#if NDIRS == 4
   0, 1, 0, -1
+#elif NDIRS == 8
+  -1, 0, 1, 1, 1, 0, -1, -1
+#endif
 };
 int ydirection[NDIRS] = {
+#if NDIRS == 4
   -1, 0, 1, 0
+#elif NDIRS == 8
+  1, 1, 1, 0, -1, -1, -1, 0
+#endif
 };
 
 float temp_aspect[NNEIGHBORS] = {

--- a/DHSVM/sourcecode/data.h
+++ b/DHSVM/sourcecode/data.h
@@ -200,8 +200,9 @@ typedef struct {
 } METLOCATION;
 
 typedef struct {
-  int NGrids;            
-  int Decimal;  
+  int utmzone;                  /* utm zone used as reference for all geospatial input */
+  int NGrids;                   /* total met grids used for memory allocation, must >= actual grids used */
+  int Decimal;                  /* decimal point of met grid coordinates as used in the file name */
   float LatNorth;               /* extreme north latitude */
   float LonEast;                /* extreme east longitude */
   float LatSouth;               /* extreme south latitude */

--- a/DHSVM/sourcecode/deg2utm.c
+++ b/DHSVM/sourcecode/deg2utm.c
@@ -18,7 +18,7 @@
 #include "functions.h"
 #include "constants.h"
 
-void deg2utm(float la, float lo, float *x, float *y)
+void deg2utm(float la, float lo, float *x, float *y, int zone)
 {
    float a, c, v, e2, e2cuadrada, S, deltaS, epsilon, a1, a2, j2, j4, j6;
    float alfa, beta, gama, Bm, xx, yy, ta;
@@ -32,8 +32,12 @@ void deg2utm(float la, float lo, float *x, float *y)
    
    lat = la * ( PI / 180 );
    lon = lo * ( PI / 180 );
-
-   Huso = floor ( ( lo / 6 ) + 31);
+   
+   /* The coordinates of DHSVM raster input are based on a single utm zone although some large basins
+      can cross more than 1 utm zones. To map the meteorological grids to DHSVM spatial input (from lat & lon
+      to utm x & y), the utm zone is fixed in conversion based on user input. */ 
+   //Huso = floor ( ( lo / 6 ) + 31);
+   Huso = abs(zone);
    S = 6 * Huso  - 183;
    deltaS = lon - ( S * ( PI / 180 ) );
 

--- a/DHSVM/sourcecode/functions.h
+++ b/DHSVM/sourcecode/functions.h
@@ -60,7 +60,7 @@ void CheckOut(OPTIONSTRUCT *Options, LAYER Veg, LAYER Soil,
 
 unsigned char dequal(double a, double b);
 
-void deg2utm(float la, float lo, float *x, float *y);
+void deg2utm(float la, float lo, float *x, float *y, int zone);
 
 void draw(DATE *Day, int first, int DayStep, MAPSIZE *Map, int NGraphics,
 	  int *which_graphics, VEGTABLE *VType, SOILTABLE *SType, SNOWPIX **SnowMap, 

--- a/DHSVM/sourcecode/settings.h
+++ b/DHSVM/sourcecode/settings.h
@@ -158,7 +158,7 @@ enum KEYS {
   MM5_rows, MM5_cols, MM5_ext_north, MM5_ext_west, MM5_dy, MM5_precip_dist, MM5_precip_freq,
   /* grid information */
   grid_ext_north=0, grid_ext_south, grid_ext_east, grid_ext_west, tot_grid, decim,
-  grid_met_file, file_prefix,
+  grid_met_file, file_prefix, utm_zone,
   /* Soil information */
   soil_description = 0, lateral_ks, exponent, depth_thresh, max_infiltration, capillary_drive,
   soil_albedo, number_of_layers, porosity, pore_size, bubbling_pressure, field_capacity,


### PR DESCRIPTION
I made `Avalanche()` work in parallel, which I missed before.  I parallelized this routine in a manner consistent with surface and subsurface routing.  Because of what I consider logic errors in the original, my parallel version may not produce spatial `Snow[][].Swq` identical to the original, but the aggregate Swq seems identical in the tests I ran. 
I am concerned that `Snow[][].PackWater` and `Snow[][].SurfWater` could be left with values that are inconsistent with redistributed `Snow[][].Swq`. Further testing may be needed.  